### PR TITLE
DTSPO-15909 - Migrating App Insights

### DIFF
--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = data.azurerm_key_vault.my_time_key_vault.id
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -87,19 +87,19 @@ resource "azurerm_resource_group" "rg" {
   tags = var.common_tags
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.component}-appinsights-${var.env}"
-  location            = var.appinsights_location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}-${var.component}-appinsights"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
 
-  tags = var.common_tags
+  common_tags = var.common_tags
+}
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }


### PR DESCRIPTION
Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

Change description
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.